### PR TITLE
feat(search): pagination

### DIFF
--- a/handlers/search.go
+++ b/handlers/search.go
@@ -60,9 +60,10 @@ func Search(c *fiber.Ctx, db *gorm.DB) error {
 	}
 
 	return c.Status(200).JSON(fiber.Map{
-		"status":       200,
-		"message":      "OK",
-		"continuation": index + 1,
-		"results":      formattedResults,
+		"status":   200,
+		"message":  "OK",
+		"continue": len(results) == 10,
+		"index":    index,
+		"results":  formattedResults,
 	})
 }


### PR DESCRIPTION
Now `/search` show only 10 results at time:

```http
GET https://api.gitarchived.org/search?q=MYREPO

{
  "continuation": 2,
  "results": [{}, {}, {}, {}, {}, {}, {}, {}, {}, {}]
}
```

```http
GET https://api.gitarchived.org/search?q=MYREPO&index=2

{
  "continuation": 3,
  "results": [{}, {}, {}, {}, {}, {}, {}, {}, {}, {}]
}
```

*`index` by default is `1`*